### PR TITLE
Fix auth cache for Laravel 13 serialization changes

### DIFF
--- a/src/Plytix.php
+++ b/src/Plytix.php
@@ -2,6 +2,7 @@
 
 namespace Esign\Plytix;
 
+use DateTimeImmutable;
 use Esign\Plytix\Pagination\PagedPaginator;
 use Esign\Plytix\Requests\TokenRequest;
 use Illuminate\Support\Facades\Cache;
@@ -27,7 +28,9 @@ class Plytix extends Connector implements HasPagination
     protected function defaultAuth(): ?Authenticator
     {
         $cacheStore = Cache::store(config('plytix.authenticator_cache.store'));
-        $cachedAuthenticator = $cacheStore->get(config('plytix.authenticator_cache.key'));
+        $cachedAuthenticator = $this->buildCachedAuthenticator(
+            $cacheStore->get(config('plytix.authenticator_cache.key'))
+        );
 
         if ($cachedAuthenticator instanceof PlytixTokenAuthenticator && ! $cachedAuthenticator->hasExpired()) {
             return $cachedAuthenticator;
@@ -42,11 +45,38 @@ class Plytix extends Connector implements HasPagination
 
         $cacheStore->put(
             key: config('plytix.authenticator_cache.key'),
-            value: $authenticator,
+            value: [
+                'token' => $authenticator->token,
+                'expiresAt' => $authenticator->expiresAt->getTimestamp(),
+            ],
             ttl: $authenticator->expiresAt
         );
 
         return $authenticator;
+    }
+
+    protected function buildCachedAuthenticator(mixed $cachedAuthenticator): ?PlytixTokenAuthenticator
+    {
+        if (! is_array($cachedAuthenticator)) {
+            return null;
+        }
+
+        $token = $cachedAuthenticator['token'] ?? null;
+
+        if (! is_string($token)) {
+            return null;
+        }
+
+        $expiresAt = $cachedAuthenticator['expiresAt'] ?? null;
+
+        if (! is_int($expiresAt)) {
+            return null;
+        }
+
+        return new PlytixTokenAuthenticator(
+            token: $token,
+            expiresAt: new DateTimeImmutable('@' . $expiresAt),
+        );
     }
 
     protected function resolveRateLimitStore(): RateLimitStore

--- a/tests/Feature/PlytixTest.php
+++ b/tests/Feature/PlytixTest.php
@@ -55,6 +55,25 @@ final class PlytixTest extends TestCase
     }
 
     #[Test]
+    public function it_can_request_a_new_token_when_a_legacy_cached_authenticator_object_is_present(): void
+    {
+        Cache::store(config('plytix.authenticator_cache.store'))->put(
+            config('plytix.authenticator_cache.key'),
+            new PlytixTokenAuthenticator('legacy-token', new DateTimeImmutable('+1 hour')),
+        );
+        $plytix = new Plytix();
+        $mockClient = MockClient::global([
+            MockResponseFixture::make(fixtureName: 'token.json', status: 200),
+            MockResponseFixture::make(fixtureName: 'V2/create-product.json', status: 201),
+        ]);
+
+        $plytix->send(new CreateProductRequest(['sku' => '12345']));
+
+        $mockClient->assertSentCount(1, TokenRequest::class);
+        $mockClient->assertSentCount(1, CreateProductRequest::class);
+    }
+
+    #[Test]
     public function it_can_use_a_cached_token_when_performing_multiple_requests(): void
     {
         $this->storeAccessTokenInCache(new DateTimeImmutable('+1 hour'));
@@ -121,7 +140,10 @@ final class PlytixTest extends TestCase
     {
         Cache::store(config('plytix.authenticator_cache.store'))->put(
             config('plytix.authenticator_cache.key'),
-            new PlytixTokenAuthenticator('fake-token', $expiresAt),
+            [
+                'token' => 'fake-token',
+                'expiresAt' => $expiresAt->getTimestamp(),
+            ],
         );
     }
 }


### PR DESCRIPTION
Laravel 13 tightened cache unserialization through the cache.serializable_classes setting. Because we previously cached the full PlytixTokenAuthenticator object, some cache drivers could no longer hydrate it, which caused Plytix to request a new token for every request.

Store a minimal array payload in cache instead of the authenticator object, rebuild the authenticator from that payload when it is valid, and ignore legacy cached authenticator objects so they are replaced by a fresh token. Add coverage for the new cache format and the legacy-object fallback.
